### PR TITLE
Install jupyter-server-proxy and aiohttp via conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,9 @@ channels:
   - conda-forge
 
 dependencies:
+  - aiohttp
   - jupyter_contrib_nbextensions
+  - jupyter-server-proxy
   - jupyterhub-singleuser
   - python=3.10
   - nbgitpuller
@@ -17,6 +19,6 @@ dependencies:
   - scikit-image
   - h5py
   - openblas
-  - pip:
-    - jupyter-server-proxy @ git+https://github.com/jupyterhub/jupyter-server-proxy.git
-    - aiohttp
+# - pip:
+#   - some-package-that-can-only-be-installed-with-pip
+#


### PR DESCRIPTION
Hi @nmearl!

I'm opening this PR to request that you rebuild this image so that it gets more recent dependencies that have been patched from a known vulnerability. Note that aiohttp and jupyter-server-proxy are available in their latest versions at conda-forge, so they don't have to be installed via `pip`.

If you think its okay, could you merge this and update to use this image instead at https://cosmicds.2i2c.cloud/services/configurator/?